### PR TITLE
fix: staticcheck [S1004]

### DIFF
--- a/pkg/chunkstream/chunkstream_test.go
+++ b/pkg/chunkstream/chunkstream_test.go
@@ -45,7 +45,7 @@ func TestWriter(t *testing.T) {
 	}
 	for _, h := range headers {
 		oh := o[h.index : h.index+2]
-		if bytes.Compare(oh, h.value) != 0 {
+		if !bytes.Equal(oh, h.value) {
 			t.Errorf("expected %x at %d, found %x", h.value, h.index, oh)
 		}
 	}
@@ -77,7 +77,7 @@ func TestReader(t *testing.T) {
 		t.Errorf("%d bytes read, expected %d", n, len(b))
 	}
 
-	if bytes.Compare(o[:n], b) != 0 {
+	if !bytes.Equal(o[:n], b) {
 		t.Errorf("expected \n%s\nread \n%s", spew.Sdump(b), spew.Sdump(o[:n]))
 	}
 }
@@ -112,7 +112,7 @@ func TestOffsetReader(t *testing.T) {
 		t.Errorf("%d bytes read, expected %d", n, off+len(b))
 	}
 
-	if bytes.Compare(o[off:n], b) != 0 {
+	if !bytes.Equal(o[off:n], b) {
 		t.Errorf("expected \n%s\nread \n%s", spew.Sdump(b), spew.Sdump(o[off:n]))
 	}
 }

--- a/pkg/mpc/cointoss.go
+++ b/pkg/mpc/cointoss.go
@@ -66,7 +66,7 @@ func cointossReceive(conn Conn, seeds []Block) (out []Block, err error) {
 			return nil, err
 		}
 		rng.Read(rc[:])
-		if bytes.Compare(cs[i][:], rc[:]) != 0 {
+		if !bytes.Equal(cs[i][:], rc[:]) {
 			return nil, errors.New("commitment check failed")
 		}
 

--- a/pkg/mpc/mpc_test.go
+++ b/pkg/mpc/mpc_test.go
@@ -65,7 +65,7 @@ func TestTranspose(t *testing.T) {
 	}
 
 	transposeMatrix(input, 16, 4)
-	if bytes.Compare(input, output) != 0 {
+	if !bytes.Equal(input, output) {
 		t.Error("output mismatch")
 		t.FailNow()
 	}

--- a/pkg/mpc/ot_test.go
+++ b/pkg/mpc/ot_test.go
@@ -73,7 +73,7 @@ func testOT(
 		} else {
 			expected = values[i][1]
 		}
-		if bytes.Compare(res[i][:], expected[:]) != 0 {
+		if !bytes.Equal(res[i][:], expected[:]) {
 			return errors.New("received unexpected value")
 		}
 	}

--- a/pkg/mpc/psz_test.go
+++ b/pkg/mpc/psz_test.go
@@ -108,7 +108,7 @@ func testPSZ(vlen, ilen int) error {
 		i := sort.Search(ilen, func(i int) bool {
 			return bytes.Compare(v, results[i]) <= 0
 		})
-		if i == ilen || bytes.Compare(v, results[i]) != 0 {
+		if i == ilen || !bytes.Equal(v, results[i]) {
 			return errors.New("missing expected result from intersection")
 		}
 	}

--- a/pkg/service/network.go
+++ b/pkg/service/network.go
@@ -70,7 +70,7 @@ type pbNetworks []*pb.Network
 
 func (n pbNetworks) Find(key []byte) *pb.Network {
 	for _, in := range n {
-		if bytes.Compare(in.Key.Public, key) == 0 {
+		if bytes.Equal(in.Key.Public, key) {
 			return in
 		}
 	}

--- a/pkg/vpn/network.go
+++ b/pkg/vpn/network.go
@@ -150,7 +150,7 @@ func (h *Networks) findIndexByKey(key []byte) (int, bool) {
 	i := sort.Search(end, func(i int) bool {
 		return bytes.Compare(key, h.networks[i].CAKey()) >= 0
 	})
-	return i, i < end && bytes.Compare(key, h.networks[i].CAKey()) == 0
+	return i, i < end && bytes.Equal(key, h.networks[i].CAKey())
 }
 
 func newNetworkBootstrap(n *Networks, peer *Peer) *networkBootstrap {
@@ -358,10 +358,10 @@ func (h *networkBootstrap) handleNetworkBindings(discriminator uint32, networkBi
 	for i, pb := range peerNetworkBindings {
 		b := networkBindings[i]
 
-		if bytes.Compare(h.peer.Certificate.Key, pb.Certificate.Key) != 0 {
+		if bytes.Equal(h.peer.Certificate.Key, pb.Certificate.Key) {
 			return errors.New("init and network certificate key mismatch")
 		}
-		if bytes.Compare(certificateParentKey(b.Certificate), certificateParentKey(pb.Certificate)) != 0 {
+		if bytes.Equal(certificateParentKey(b.Certificate), certificateParentKey(pb.Certificate)) {
 			return errors.New("network ca mismatch")
 		}
 		if pb.Port > uint32(math.MaxUint16) {


### PR DESCRIPTION
`bytes.Equal(x, y)` is preferred over `bytes.Compare(x, y) == 0`