### PR TITLE
chore: fix gosimple linter results

### DIFF
--- a/pkg/mpc/prc.go
+++ b/pkg/mpc/prc.go
@@ -1,8 +1,9 @@
 package mpc
 
-import "crypto/cipher"
-
-import "crypto/aes"
+import (
+	"crypto/aes"
+	"crypto/cipher"
+)
 
 // NewPseudorandomCode ...
 func NewPseudorandomCode(k0, k1, k2, k3 Block) (*PseudorandomCode, error) {
@@ -36,5 +37,4 @@ func (p *PseudorandomCode) Encode(dst *Block512, b Block) {
 	p.cipher1.Encrypt(dst[16:32], b[:])
 	p.cipher2.Encrypt(dst[32:48], b[:])
 	p.cipher3.Encrypt(dst[48:64], b[:])
-	return
 }

--- a/pkg/ppspp/bin_timeout_queue.go
+++ b/pkg/ppspp/bin_timeout_queue.go
@@ -55,7 +55,6 @@ func (s *binTimeoutQueue) Push(b binmap.Bin, t time.Time) {
 		Time: t,
 		Bin:  b,
 	}
-	return
 }
 
 // Peek ...

--- a/pkg/ppspp/channel.go
+++ b/pkg/ppspp/channel.go
@@ -174,7 +174,7 @@ func (c *channel) dequeuePong() *codec.Pong {
 
 	p := &codec.Pong{
 		Nonce: uint64(c.pongNonce),
-		Delay: uint64(time.Now().Sub(c.pongTime)),
+		Delay: uint64(time.Since(c.pongTime)),
 	}
 
 	c.pongNonce = binmap.None

--- a/pkg/queue/ring.go
+++ b/pkg/queue/ring.go
@@ -25,7 +25,6 @@ func (r *Ring) Resize(size uint64) {
 	if r.size&r.mask != 0 {
 		panic("ring size should be power of 2")
 	}
-	return
 }
 
 // Head ...

--- a/pkg/rtmpingress/pubsub.go
+++ b/pkg/rtmpingress/pubsub.go
@@ -85,7 +85,7 @@ type splitSeqhdr struct {
 }
 
 func (s *splitSeqhdr) sendmeta(pkt av.Packet) error {
-	if bytes.Compare(s.hdrpkt.Metadata, pkt.Metadata) != 0 {
+	if !bytes.Equal(s.hdrpkt.Metadata, pkt.Metadata) {
 		if err := s.cb(av.Packet{
 			Type: av.Metadata,
 			Data: pkt.Metadata,
@@ -104,7 +104,7 @@ func (s *splitSeqhdr) do(pkt av.Packet) error {
 			return err
 		}
 		if pkt.IsKeyFrame {
-			if bytes.Compare(s.hdrpkt.VSeqHdr, pkt.VSeqHdr) != 0 {
+			if !bytes.Equal(s.hdrpkt.VSeqHdr, pkt.VSeqHdr) {
 				if err := s.cb(av.Packet{
 					Type: av.H264DecoderConfig,
 					Data: pkt.VSeqHdr,
@@ -119,7 +119,7 @@ func (s *splitSeqhdr) do(pkt av.Packet) error {
 		if err := s.sendmeta(pkt); err != nil {
 			return err
 		}
-		if bytes.Compare(s.hdrpkt.ASeqHdr, pkt.ASeqHdr) != 0 {
+		if !bytes.Equal(s.hdrpkt.ASeqHdr, pkt.ASeqHdr) {
 			if err := s.cb(av.Packet{
 				Type: av.AACDecoderConfig,
 				Data: pkt.ASeqHdr,


### PR DESCRIPTION
```
pkg/queue/ring.go:28:2: S1023: redundant `return` statement (gosimple)
	return
	^
pkg/mpc/prc.go:39:2: S1023: redundant `return` statement (gosimple)
	return
	^
pkg/ppspp/bin_timeout_queue.go:58:2: S1023: redundant `return` statement (gosimple)
	return
	^
pkg/rtmpingress/pubsub.go:88:5: S1004: should use !bytes.Equal(s.hdrpkt.Metadata, pkt.Metadata) instead (gosimple)
	if bytes.Compare(s.hdrpkt.Metadata, pkt.Metadata) != 0 {
	   ^
pkg/rtmpingress/pubsub.go:107:7: S1004: should use !bytes.Equal(s.hdrpkt.VSeqHdr, pkt.VSeqHdr) instead (gosimple)
			if bytes.Compare(s.hdrpkt.VSeqHdr, pkt.VSeqHdr) != 0 {
			   ^
pkg/rtmpingress/pubsub.go:122:6: S1004: should use !bytes.Equal(s.hdrpkt.ASeqHdr, pkt.ASeqHdr) instead (gosimple)
		if bytes.Compare(s.hdrpkt.ASeqHdr, pkt.ASeqHdr) != 0 {
		   ^
pkg/ppspp/channel.go:177:17: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
		Delay: uint64(time.Now().Sub(c.pongTime)),
		              ^
```
