### PR TITLE
chore: fix staticcheck lint errs

### DIFF
--- a/pkg/byterope/rope_test.go
+++ b/pkg/byterope/rope_test.go
@@ -27,9 +27,7 @@ func TestCopy(t *testing.T) {
 	r := New(x, y, z)
 
 	firstHalf := make([]byte, r.Len()/2)
-	n := New(firstHalf).Copy(r...)
-	if n != len(firstHalf) {
-	}
+	New(firstHalf).Copy(r...)
 	check(t, firstHalf, []byte("first chunk of filesecond chu"))
 }
 

--- a/pkg/mpc/psz.go
+++ b/pkg/mpc/psz.go
@@ -63,6 +63,9 @@ func (p *PSZSender) Send(
 		return err
 	}
 	seeds, err := p.oprf.Send(conn, nbins, rng)
+	if err != nil {
+		return err
+	}
 
 	indices := make([]int, len(inputs))
 	for i := range inputs {

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -46,8 +46,8 @@ func (p *Pool) Get(size uint16) (b []byte) {
 // Put ...
 func (p *Pool) Put(b []byte) {
 	if i := bits.LeadingZeros16(uint16(cap(b))); i < p.n {
-		p.zones[i].Put(b)
+		p.zones[i].Put(&b)
 	} else {
-		p.zones[p.n-1].Put(b)
+		p.zones[p.n-1].Put(&b)
 	}
 }

--- a/pkg/ppspp/scheduler.go
+++ b/pkg/ppspp/scheduler.go
@@ -238,15 +238,15 @@ func (r *Scheduler) sendPeerData(p *Peer, t time.Time) {
 			}
 		}
 
-		if atomic.LoadInt64(&r.sent) > 100 {
-			// r.logger.Debug(
-			// 	"data",
-			// 	zap.Int("sent", nw),
-			// 	zap.Int("missing", no),
-			// 	zap.Int("flightSize", p.ledbat.FlightSize()),
-			// 	zap.Int("cwnd", p.ledbat.CWND()),
-			// )
-		}
+		//if atomic.LoadInt64(&r.sent) > 100 {
+		// r.logger.Debug(
+		// 	"data",
+		// 	zap.Int("sent", nw),
+		// 	zap.Int("missing", no),
+		// 	zap.Int("flightSize", p.ledbat.FlightSize()),
+		// 	zap.Int("cwnd", p.ledbat.CWND()),
+		// )
+		//}
 
 		pool.Put(b)
 
@@ -297,15 +297,15 @@ func (r *Scheduler) peerRequestCapacity(p *Peer) int {
 		capacity = planForIntervals * 120
 	}
 
-	if chunkInterval != 0 {
-		// r.logger.Debug(
-		// 	"capacity",
-		// 	zap.Int("capacity", capacity),
-		// 	zap.Duration("p.ledbat.RTTMean()", p.ledbat.RTTMean()),
-		// 	zap.Duration("planforDuration", planForDuration),
-		// 	zap.Duration("chunkInterval", chunkInterval),
-		// )
-	}
+	//if chunkInterval != 0 {
+	// r.logger.Debug(
+	// 	"capacity",
+	// 	zap.Int("capacity", capacity),
+	// 	zap.Duration("p.ledbat.RTTMean()", p.ledbat.RTTMean()),
+	// 	zap.Duration("planforDuration", planForDuration),
+	// 	zap.Duration("chunkInterval", chunkInterval),
+	// )
+	//}
 
 	return capacity
 }

--- a/pkg/ppspp/scheduler_test.go
+++ b/pkg/ppspp/scheduler_test.go
@@ -16,12 +16,10 @@ func TestChunkScheduler(t *testing.T) {
 	rand.Seed(1)
 	p := float64(1)
 	c := 300
-	var ns []int
 	for i := 0; i < c; i++ {
 		p -= 1 / float64(c)
 		if rand.Float64() < p {
 			available.Set(binmap.Bin(i) * 2)
-			ns = append(ns, i*2)
 		}
 	}
 

--- a/pkg/rpc/rpc.go
+++ b/pkg/rpc/rpc.go
@@ -54,7 +54,7 @@ func handleCancel(c *conn, m *pb.Call) {
 
 func readCall(r io.Reader) (*pb.Call, error) {
 	b := readBuffers.Get().([]byte)
-	defer readBuffers.Put(b)
+	defer readBuffers.Put(&b)
 
 	l, err := binary.ReadUvarint(bytereader.New(r))
 	if err != nil {

--- a/pkg/service/pubsub.go
+++ b/pkg/service/pubsub.go
@@ -58,6 +58,10 @@ func NewPubSubServer(svc *NetworkServices, key *pb.Key, salt []byte) (*PubSubSer
 		HostId: svc.Host.ID().Bytes(nil),
 		Port:   uint32(port),
 	})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 	_, err = svc.HashTable.Set(ctx, key, salt, b)
 	if err != nil {
 		cancel()


### PR DESCRIPTION
None of the protobuf swap/upgrade was attempted, it doesn't seem as easy as the
errs are making it seem but I will need to look more.
```
pkg/pool/pool.go:49:17: SA6002: argument should be pointer-like to avoid allocations (staticcheck)
		p.zones[i].Put(b)
		              ^
pkg/pool/pool.go:51:21: SA6002: argument should be pointer-like to avoid allocations (staticcheck)
		p.zones[p.n-1].Put(b)
		                  ^
pkg/rpc/rpc.go:57:2: SA6002: argument should be pointer-like to avoid allocations (staticcheck)
	defer readBuffers.Put(b)
	^
pkg/byterope/rope_test.go:31:2: SA9003: empty branch (staticcheck)
	if n != len(firstHalf) {
	^
pkg/ppspp/scheduler.go:241:3: SA9003: empty branch (staticcheck)
		if atomic.LoadInt64(&r.sent) > 100 {
		^
pkg/ppspp/scheduler.go:300:2: SA9003: empty branch (staticcheck)
	if chunkInterval != 0 {
	^
pkg/mpc/psz.go:65:9: SA4006: this value of `err` is never used (staticcheck)
	seeds, err := p.oprf.Send(conn, nbins, rng)
	       ^
pkg/mpc/ot_test.go:20:2: SA4006: this value of `receive` is never used (staticcheck)
	receive := []bool{}
	^
pkg/service/pubsub.go:57:5: SA4006: this value of `err` is never used (staticcheck)
	b, err := proto.Marshal(&pb.NetworkAddress{
	   ^
pkg/ppspp/scheduler_test.go:24:15: SA4010: this result of append is never used, except maybe in other appends (staticcheck)
			ns = append(ns, i*2)
			           ^
pkg/rpc/rpc.go:126:28: SA1019: proto.MessageName is deprecated: Use protoreflect.MessageDescriptor.FullName instead.  (staticcheck)
			TypeUrl: anyURLPrefix + proto.MessageName(v),
			                        ^
pkg/rpc/rpc.go:221:7: SA1019: proto.MessageType is deprecated: Use protoregistry.GlobalTypes.FindMessageByName instead.  (staticcheck)
	k := proto.MessageType(n)
	     ^
pkg/rpc/rpc.go:234:8: SA1019: proto.MessageType is deprecated: Use protoregistry.GlobalTypes.FindMessageByName instead.  (staticcheck)
	at := proto.MessageType(n)
	      ^
pkg/rpc/client.go:8:2: SA1019: Package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (staticcheck)
	"github.com/golang/protobuf/proto"
	^
pkg/rpc/host.go:12:2: SA1019: Package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (staticcheck)
	"github.com/golang/protobuf/proto"
	^
pkg/rpc/rpc.go:16:2: SA1019: Package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (staticcheck)
	"github.com/golang/protobuf/proto"
	^
```
