### PR TITLE
allow printing add-profile bits as json

### DIFF
--- a/cmd/svc/commandfuncs.go
+++ b/cmd/svc/commandfuncs.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -21,6 +22,7 @@ import (
 	"github.com/MemeLabs/strims/internal/network"
 	"github.com/MemeLabs/strims/internal/session"
 	"github.com/MemeLabs/strims/pkg/apis/type/key"
+	"github.com/MemeLabs/strims/pkg/errutil"
 	"github.com/MemeLabs/strims/pkg/httputil"
 	"github.com/MemeLabs/strims/pkg/vnic"
 	"github.com/MemeLabs/strims/pkg/vpn"
@@ -255,8 +257,25 @@ func addProfileCmd(fs Flags) error {
 	if err != nil {
 		return err
 	}
-	log.Println(id)
-	log.Println(base64.StdEncoding.EncodeToString(key))
+
+	jsonOutput, err := fs.Bool("json")
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		data := struct {
+			ID  uint64 `json:"id"`
+			Key string `json:"key"`
+		}{
+			ID:  id,
+			Key: base64.StdEncoding.EncodeToString(key),
+		}
+		fmt.Println(string(errutil.Must(json.MarshalIndent(data, "", "  "))))
+	} else {
+		log.Println(id)
+		log.Println(base64.StdEncoding.EncodeToString(key))
+	}
 
 	return nil
 }

--- a/cmd/svc/commands.go
+++ b/cmd/svc/commands.go
@@ -64,6 +64,7 @@ func init() {
 			fs.String("config", "", "Configuration file")
 			fs.String("username", "", "Profile username")
 			fs.String("password", "", "Profile password")
+			fs.Bool("json", false, "Print output as json")
 			return fs
 		}(),
 	})

--- a/cmd/svc/main.go
+++ b/cmd/svc/main.go
@@ -85,3 +85,10 @@ func (f Flags) Int(name string) (int, error) {
 	}
 	return 0, nil
 }
+
+func (f Flags) Bool(name string) (bool, error) {
+	if v := f.String(name); v != "" {
+		return strconv.ParseBool(v)
+	}
+	return false, nil
+}


### PR DESCRIPTION
so I can merge with yq like so:

```
yq ".session.headless += `go run ./cmd/svc add-profile -config ./hack/svc/config.yaml -username dev1 -password secret -json`" tmp.yaml
```

Signed-off-by: jbpratt <jbpratt78@gmail.com>
